### PR TITLE
[WIP] Add scan-funds command

### DIFF
--- a/src/commands/scan-funds.js
+++ b/src/commands/scan-funds.js
@@ -1,0 +1,174 @@
+/*
+  Scans first 20 addresses of each derivation path for history and balance.
+  If any of them had a history, scans the next 20, until it reaches a batch of 20
+  addresses with no history.
+  derivation settings:
+  145 - BIP44 standard path for Bitcoin Cash
+  245 - BIP44 standard path for SLP tokens
+  0 - Used by common software like the Bitcoin.com wallet and Honest.cash
+*/
+
+"use strict"
+
+const config = require("../../config")
+// Mainnet.
+const BCHJS = new config.BCHLIB({ restURL: config.MAINNET_REST })
+
+const { Command, flags } = require("@oclif/command")
+
+class ScanFunds extends Command {
+  constructor(argv, config) {
+    super(argv, config)
+
+    this.BCHJS = BCHJS
+
+    this.derivePathes = [
+      "m/44'/145'/0'/0", // BCH BIP 44 standard
+      "m/44'/0'/0'/0", // Bitcoin.com wallet
+      "m/44'/245'/0'/0" // SLP BIP44 standard
+    ]
+  }
+
+  async run() {
+    try {
+      const { flags } = this.parse(ScanFunds)
+
+      // Ensure flags meet qualifiying critieria.
+      this.validateFlags(flags)
+
+      const rootSeed = await this.BCHJS.Mnemonic.toSeed(flags.mnemonic)
+      const masterHDNode = this.BCHJS.HDNode.fromSeed(rootSeed)
+
+      this.derivePathes.forEach(derivePath => {
+        this.scanDerivationPath(masterHDNode, derivePath).then(
+          addressesWithHistory => {
+            if (addressesWithHistory.length === 0) {
+              console.log(`No history found on derivation path ${derivePath}`)
+            } else {
+              addressesWithHistory.forEach(element => {
+                console.log(
+                  `${element.address} - confirmed balance: ${element.balance.confirmed} unconfirmed balance: ${element.balance.unconfirmed}`
+                )
+              })
+            }
+          }
+        )
+      })
+    } catch (err) {
+      if (err.message) console.log(err.message)
+      else console.log(`Error in .run: `, err)
+      //console.log(`Error in scan-funds.js/run: `, err)
+      throw err
+    }
+  }
+
+  // Generates a child HDNode from masterHDNode using derivePath
+  generateDerivedAddress(masterHDNode, derivePath) {
+    try {
+      const derivedHDNode = this.BCHJS.HDNode.derivePath(
+        masterHDNode,
+        derivePath
+      )
+      return this.BCHJS.HDNode.toCashAddress(derivedHDNode)
+    } catch (err) {
+      console.log("Error in generateDerivedAddress()")
+      throw err
+    }
+  }
+
+  // Queries ElectrumX for transaction history of address, if existed, gets address balance too
+  async addressHasTransactionHistoryBalance(address) {
+    try {
+      let balance = { confirmed: 0, unconfirmed: 0 }
+      const transactions = await this.BCHJS.Electrumx.transactions(
+        address
+      ).catch(err => {
+        console.log(err)
+      })
+      let hasHistory
+      if (transactions) {
+        hasHistory =
+          transactions.success && transactions.transactions.length > 0
+      }
+      if (hasHistory) {
+        const balanceData = await this.BCHJS.Electrumx.balance(address).catch(
+          err => {
+            console.log(err)
+          }
+        )
+        balance = balanceData.balance
+      }
+      return { hasHistory: hasHistory, balance: balance }
+    } catch (err) {
+      console.log("Error in addressHasTransactionHistoryBalance()")
+      throw err
+    }
+  }
+
+  // Scans the derivePath children in groups of 20 addresses, until one group has no history
+  async scanDerivationPath(masterHDNode, derivePath) {
+    try {
+      console.log(`Scanning derivation path ${derivePath}...`)
+      let addressesWithHistory = []
+      let limit = 20
+      for (let index = 0; index <= limit; index++) {
+        const derivedChildPath = `${derivePath}/${index}`
+
+        const derivedChildAdress = this.generateDerivedAddress(
+          masterHDNode,
+          derivedChildPath
+        )
+
+        const historyBalanceData = await this.addressHasTransactionHistoryBalance(
+          derivedChildAdress
+        )
+
+        if (historyBalanceData.hasHistory) {
+          addressesWithHistory.push({
+            address: derivedChildAdress,
+            balance: historyBalanceData.balance
+          })
+          limit += 20
+        }
+      }
+      return addressesWithHistory
+    } catch (err) {
+      console.log("Error in scanDerivationPath()")
+      throw err
+    }
+  }
+
+  // Validate the proper flags are passed in.
+  validateFlags(flags) {
+    // Exit if mnemonic phrase not specified.
+    const mnemonic = flags.mnemonic
+    if (!mnemonic || mnemonic === "")
+      throw new Error(`You must specify a mnemonic phrase with the -m flag.`)
+
+    // Exit if number of mnemonic words is not 12.
+    if (mnemonic.split(" ").length !== 12)
+      throw new Error(`You must specify a mnemonic phrase of 12 words.`)
+
+    return true
+  }
+}
+
+ScanFunds.description = `Scans first 20 addresses of each derivation path for
+history and balance of the given mnemonic. If any of them had a history, scans
+the next 20, until it reaches a batch of 20 addresses with no history. The -m
+flag is used to pass it a mnemonic phrase.
+
+Derivation pathes used:
+145 - BIP44 standard path for Bitcoin Cash
+245 - BIP44 standard path for SLP tokens
+0 - Used by common software like the Bitcoin.com wallet and Honest.cash
+`
+
+ScanFunds.flags = {
+  mnemonic: flags.string({
+    char: "m",
+    description: "mnemonic phrase to generate addresses, wrapped in quotes"
+  })
+}
+
+module.exports = ScanFunds

--- a/test/commands/a15.scan-funds.test.js
+++ b/test/commands/a15.scan-funds.test.js
@@ -1,0 +1,102 @@
+/*
+  TODO:
+
+
+*/
+
+"use strict"
+
+const assert = require("chai").assert
+const sinon = require("sinon")
+
+// Library under test.
+const ScanFunds = require("../../src/commands/scan-funds")
+const config = require("../../config")
+
+// Mock data
+const { bitboxMock } = require("../mocks/bitbox")
+
+// Set default environment variables for unit tests.
+if (!process.env.TEST) process.env.TEST = "unit"
+
+describe("#scanFunds", () => {
+  let BCHJS
+  let scanFunds
+  let sandbox
+
+  beforeEach(() => {
+    // By default, use the mocking library instead of live calls.
+    BCHJS = bitboxMock
+
+    sandbox = sinon.createSandbox()
+    sandbox.reset()
+    sandbox.resetHistory()
+    sandbox.restore()
+
+    scanFunds = new ScanFunds()
+    scanFunds.BCHJS = BCHJS
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe("#generateDerivedAddress", () => {
+    it("should call derivePath and toCashAddress once.", () => {
+      scanFunds.BCHJS.HDNode.derivePath.resetHistory()
+      scanFunds.BCHJS.HDNode.toCashAddress.resetHistory()
+      scanFunds.generateDerivedAddress({}, "")
+
+      assert.equal(scanFunds.BCHJS.HDNode.derivePath.calledOnce, true)
+      assert.equal(scanFunds.BCHJS.HDNode.toCashAddress.calledOnce, true)
+    })
+  })
+
+  describe("#addressHasTransactionHistoryBalance", () => {
+    it("should have both hasHistory and balance keys in retuen value.", () => {
+      scanFunds
+        .addressHasTransactionHistoryBalance("")
+        .then(function(response) {
+          assert.hasAllKeys(response, ["hasHistory", "balance"])
+        })
+    })
+  })
+
+  describe("#scanDerivationPath", () => {
+    it("should return an empty array.", () => {
+      scanFunds.scanDerivationPath({}).then(addressesWithHistory => {
+        assert.lengthOf(addressesWithHistory, 0)
+      })
+    })
+  })
+
+  describe("#validateFlags", () => {
+    it("should throw error if mnemonic is not supplied.", () => {
+      try {
+        scanFunds.validateFlags({})
+      } catch (err) {
+        assert.include(
+          err.message,
+          `You must specify a mnemonic phrase with the -m flag.`,
+          "Expected error message."
+        )
+      }
+    })
+
+    it("should throw error is mnemonic flag is specified with less than 12 words.", () => {
+      try {
+        const flags = {
+          mnemonic: `test mnemonic fail`
+        }
+
+        scanFunds.validateFlags(flags)
+      } catch (err) {
+        assert.include(
+          err.message,
+          `You must specify a mnemonic phrase of 12 words.`,
+          "Expected error message."
+        )
+      }
+    })
+  })
+})

--- a/test/mocks/bitbox.js
+++ b/test/mocks/bitbox.js
@@ -142,6 +142,18 @@ const utxos = {
   scriptPubKey: "76a914fbc8766434a0d6fee839380f1c44862b57e19b8388ac"
 }
 
+const ElectrumXTransactionsResponse = {
+  success: true,
+  transactions: [],
+  catch: sinon.stub()
+}
+
+const ElectrumXBalanceResponse = {
+  success: true,
+  balancec: { confirmed: 0, unconfirmed: 0 },
+  catch: sinon.stub()
+}
+
 class mockTransactionBuilder {
   constructor() {
     this.hashTypes = {
@@ -210,6 +222,10 @@ const bitboxMock = {
     fromWIF: sinon.stub().returns({}),
     toCashAddress: sinon.stub().returns({}),
     toPublicKey: sinon.stub().returns({})
+  },
+  Electrumx: {
+    transactions: sinon.stub().returns(ElectrumXTransactionsResponse),
+    balance: sinon.stub().returns(ElectrumXBalanceResponse)
   }
 }
 


### PR DESCRIPTION
Starting with a 12 word mnemonic, it scans these derivations:
    m/44'/145'/0'/0/* (BCH BIP 44 standard)
    m/44'/0'/0'/0/* (Bitcoin.com wallet)
    m/44'/245'/0'/0/* (SLP BIP44 standard)
    It queries the balance of the first 20 addresses for each derivation for a transaction history.
        If a historical transaction for any of the 20 addresses is found, then the next 20 addresses will be scanned. This continues until a batch of 20 addresses with no transaction history is found.
        Any time an address with transaction is found, it's current blockchain balance is queried and the address and balance will be printed on the screen.
